### PR TITLE
Reduce pkg size

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "4.0.0",
   "description": "A node.js client library to the IP reputation service/iprepd",
   "main": "lib/client.js",
+  "files": [
+    "lib/client.js"
+  ],
   "scripts": {
     "test": "scripts/test-local.sh"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ip-reputation-js-client",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A node.js client library to the IP reputation service/iprepd",
   "main": "lib/client.js",
   "files": [


### PR DESCRIPTION
fixes #15 with @pdehaan's patch

Drops the package size to 7.8K. I'm leaving the license in for now.

```
~/ip-reputation-js-client - [master] » npm pack
ip-reputation-js-client-4.0.0.tgz
~/ip-reputation-js-client - [master●] » tar -tf ip-reputation-js-client-4.0.0.tgz
package/package.json
package/.dockerignore
package/.eslintrc.js
package/.travis.yml
package/docker-compose.yml
package/Gruntfile.js
package/LICENSE
package/README.md
package/grunttasks/bump.js
package/grunttasks/copyright.js
package/grunttasks/eslint.js
package/grunttasks/nsp.js
package/grunttasks/version.js
package/lib/client.js
package/scripts/test-local.sh
package/test/iprepd.yaml
package/test/local/reputation_service_client_tests.js
~/ip-reputation-js-client - [master●] » ls -lash *.tgz | awk '{ print $6 }'
12K
~/ip-reputation-js-client - [reduce-pkg-size-15●] » npm pack
ip-reputation-js-client-4.0.1.tgz
~/ip-reputation-js-client - [reduce-pkg-size-15●] » tar -tf ip-reputation-js-client-4.0.1.tgz
package/package.json
package/LICENSE
package/README.md
package/lib/client.js
~/ip-reputation-js-client - [reduce-pkg-size-15●] » ls -lash *.tgz | awk '{ print $6 }'
7.8K
``` 