### PR TITLE
Remove use of legacy endpoints

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -99,7 +99,9 @@ client.prototype.getTyped = function (type, obj) {
     }
   }).timeout(this.timeout).then(function (response) {
     if (response && response.body && response.statusCode) {
-      response.body.ip = obj;
+      if (type === 'ip') {
+        response.body.ip = obj;
+      }
     }
     return response;
   });

--- a/lib/client.js
+++ b/lib/client.js
@@ -25,13 +25,7 @@ var ipSchema = Joi.string().ip({
   cidr: false
 });
 
-var emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/;
-var emailValidate = function(email) {
-  if (emailRegex.test(email)) {
-    return true;
-  }
-  return false;
-};
+var emailSchema = Joi.string().email();
 
 var validate = function(type, obj) {
   if (type === 'ip') {
@@ -39,7 +33,7 @@ var validate = function(type, obj) {
       return new Error('Invalid IP.');
     }
   } else if (type === 'email') {
-    if (! emailValidate(obj)){
+    if (Joi.validate(obj, emailSchema).error !== null) {
       return new Error('Invalid Email.');
     }
   } else {
@@ -103,7 +97,12 @@ client.prototype.getTyped = function (type, obj) {
     hawk: {
       contentType: null
     }
-  }).timeout(this.timeout);
+  }).timeout(this.timeout).then(function (response) {
+    if (response && response.body && response.statusCode) {
+      response.body.ip = obj;
+    }
+    return response;
+  });
 };
 
 /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -25,6 +25,30 @@ var ipSchema = Joi.string().ip({
   cidr: false
 });
 
+var emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/;
+var emailValidate = function(email) {
+  if (emailRegex.test(email)) {
+    return true;
+  }
+  return false;
+};
+
+var validate = function(type, obj) {
+  if (type === 'ip') {
+    if (Joi.validate(obj, ipSchema).error !== null) {
+      return new Error('Invalid IP.');
+    }
+  } else if (type === 'email') {
+    if (! emailValidate(obj)){
+      return new Error('Invalid Email.');
+    }
+  } else {
+    return new Error('Invalid type: '+type);
+  }
+  return null;
+};
+
+
 /**
  * @class IPReputationServiceClient
  * @constructor
@@ -64,21 +88,110 @@ var client = function(config) {
 };
 
 /**
+ * @method getTyped
+ * @param {String} type Object type to get reputation for (ip or email)
+ * @param {String} obj Object to get reputation for
+ * @return {Promise}
+ */
+client.prototype.getTyped = function (type, obj) {
+  if (validate(type, obj) !== null) {
+    return Promise.reject(validate(type, obj));
+  }
+  return this.baseRequest({
+    method: 'GET',
+    uri: '/type/' + type + '/' + obj,
+    hawk: {
+      contentType: null
+    }
+  }).timeout(this.timeout);
+};
+
+/**
+ * @method updateTyped
+ * @param {String} type Object type to update the reputation for (ip or email)
+ * @param {String} obj Object to update the reputation for
+ * @param {Number} reputation a reputation/trust value from 0 to 100 inclusive (higher is more trustworthy)
+ * @return {Promise}
+ */
+client.prototype.updateTyped = function (type, obj, reputation) {
+  if (validate(type, obj) !== null) {
+    return Promise.reject(validate(type, obj));
+  }
+  return this.baseRequest({
+    method: 'PUT',
+    uri: '/type/' + type + '/' + obj,
+    hawk: {
+      payload: JSON.stringify({
+        'reputation': reputation,
+        'object': obj,
+        'type': type
+      })
+    },
+    json: {
+      'reputation': reputation,
+      'object': obj,
+      'type': type
+    }
+  }).timeout(this.timeout);
+};
+
+/**
+ * @method removeTyped
+ * @param {String} type Object type to remove an associated reputation for (ip or email)
+ * @param {String} obj Object to remove an associated reputation for
+ * @return {Promise}
+ */
+client.prototype.removeTyped = function (type, obj) {
+  if (validate(type, obj) !== null) {
+    return Promise.reject(validate(type, obj));
+  }
+  return this.baseRequest({
+    method: 'DELETE',
+    uri: '/type/' + type + '/' + obj,
+    hawk: {
+      payload: '', // force sending a hawk hash that reputation service requires
+      contentType: null
+    }
+  }).timeout(this.timeout);
+};
+
+/**
+ * @method sendViolationTyped
+ * @param {String} type Object type to record a violation for
+ * @param {String} obj Object to record a violation for
+ * @param {String} violationType an violation type to save lookup the reputation penalty for
+ * @return {Promise}
+ */
+client.prototype.sendViolationTyped = function (type, obj, violationType) {
+  if (validate(type, obj) !== null) {
+    return Promise.reject(validate(type, obj));
+  }
+  return this.baseRequest({
+    method: 'PUT',
+    uri: '/violations/type/' + type + '/' + obj,
+    hawk: {
+      payload: JSON.stringify({
+        'violation': violationType,
+        'type': type,
+        'object': obj
+      })
+    },
+    json: {
+      'violation': violationType,
+      'type': type,
+      'object': obj,
+    }
+  }).timeout(this.timeout);
+};
+
+
+/**
  * @method get
  * @param {String} ip a Joi strip.ip IP address to fetch reputation for
  * @return {Promise}
  */
 client.prototype.get = function (ip) {
-  if (Joi.validate(ip, ipSchema).error !== null) {
-    return Promise.reject(new Error('Invalid IP.'));
-  }
-  return this.baseRequest({
-    method: 'GET',
-    uri: '/' + ip,
-    hawk: {
-      contentType: null
-    }
-  }).timeout(this.timeout);
+  return this.getTyped('ip', ip);
 };
 
 /**
@@ -88,17 +201,7 @@ client.prototype.get = function (ip) {
  * @return {Promise}
  */
 client.prototype.update = function (ip, reputation) {
-  if (Joi.validate(ip, ipSchema).error !== null) {
-    return Promise.reject(new Error('Invalid IP.'));
-  }
-  return this.baseRequest({
-    method: 'PUT',
-    uri: '/' + ip,
-    hawk: {
-      payload: JSON.stringify({'reputation': reputation})
-    },
-    json: {'reputation': reputation}
-  }).timeout(this.timeout);
+  return this.updateTyped('ip', ip, reputation);
 };
 
 /**
@@ -107,17 +210,7 @@ client.prototype.update = function (ip, reputation) {
  * @return {Promise}
  */
 client.prototype.remove = function (ip) {
-  if (Joi.validate(ip, ipSchema).error !== null) {
-    return Promise.reject(new Error('Invalid IP.'));
-  }
-  return this.baseRequest({
-    method: 'DELETE',
-    uri: '/' + ip,
-    hawk: {
-      payload: '', // force sending a hawk hash that reputation service requires
-      contentType: null
-    }
-  }).timeout(this.timeout);
+  return this.removeTyped('ip', ip);
 };
 
 /**
@@ -127,17 +220,7 @@ client.prototype.remove = function (ip) {
  * @return {Promise}
  */
 client.prototype.sendViolation = function (ip, violationType) {
-  if (Joi.validate(ip, ipSchema).error !== null) {
-    return Promise.reject(new Error('Invalid IP.'));
-  }
-  return this.baseRequest({
-    method: 'PUT',
-    uri: '/violations/' + ip,
-    hawk: {
-      payload: JSON.stringify({'ip': ip, 'violation': violationType})
-    },
-    json: {'ip': ip, 'violation': violationType}
-  }).timeout(this.timeout);
+  return this.sendViolationTyped('ip', ip, violationType);
 };
 
 module.exports = client;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5014,9 +5014,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.0.tgz",
-      "integrity": "sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/test/local/reputation_service_client_tests.js
+++ b/test/local/reputation_service_client_tests.js
@@ -13,6 +13,7 @@ var client = new IPReputationClient({
   timeout: 150
 });
 var invalidIPError = new Error('Invalid IP.');
+var invalidEmailError = new Error('Invalid Email.');
 
 // Tests in this file are specifically ordered
 
@@ -69,6 +70,24 @@ test(
 );
 
 test(
+  'does not get reputation for a nonexistent email',
+  function (t) {
+    client.getTyped('email', 'not-there@example.com').then(function (response) {
+      t.equal(response.statusCode, 404);
+      t.end();
+    });
+  }
+);
+
+test(
+  'does not get reputation for a invalid email',
+  function (t) {
+    t.rejects(client.getTyped('email', 'not-an-email'), invalidEmailError);
+    t.end();
+  }
+);
+
+test(
   'does not get reputation for a invalid IP',
   function (t) {
     t.rejects(client.get('not-an-ip'), invalidIPError);
@@ -97,6 +116,26 @@ test(
   function (t) {
     t.rejects(client.sendViolation('not-an-ip', 'test_violation'), invalidIPError);
     t.end();
+  }
+);
+
+test(
+  'update reputation for new email',
+  function (t) {
+    client.updateTyped('email', 'picard@example.com', 50).then(function (response) {
+      t.equal(response.statusCode, 200);
+      t.end();
+    });
+  }
+);
+
+test(
+  'update reputation for existing email',
+  function (t) {
+    client.updateTyped('email', 'picard@example.com', 57).then(function (response) {
+      t.equal(response.statusCode, 200);
+      t.end();
+    });
   }
 );
 
@@ -133,7 +172,21 @@ test(
 );
 
 test(
-  'gets reputation for a existing IP',
+  'gets reputation for an existing IP (typed)',
+  function (t) {
+    client.getTyped('ip', '127.0.0.1').then(function (response) {
+      t.equal(response.statusCode, 200);
+      t.equal(response.body.reputation, 75);
+      t.equal(response.body.object, '127.0.0.1');
+      t.equal(response.body.reviewed, false);
+      // also response.body.lastupdated, which is dynamic (time of previous test request)
+      t.end();
+    });
+  }
+);
+
+test(
+  'gets reputation for an existing IP',
   function (t) {
     client.get('127.0.0.1').then(function (response) {
       t.equal(response.statusCode, 200);
@@ -141,6 +194,34 @@ test(
       t.equal(response.body.ip, '127.0.0.1');
       t.equal(response.body.reviewed, false);
       // also response.body.lastupdated, which is dynamic (time of previous test request)
+      t.end();
+    });
+  }
+);
+
+test(
+  'gets reputation for an existing email',
+  function (t) {
+    client.getTyped('email', 'picard@example.com').then(function (response) {
+      t.equal(response.statusCode, 200);
+      t.equal(response.body.reputation, 57);
+      t.equal(response.body.object, 'picard@example.com');
+      t.equal(response.body.reviewed, false);
+      t.end();
+    });
+  }
+);
+
+test(
+  'removes reputation for existing email',
+  function (t) {
+    client.removeTyped('email', 'picard@example.com').then(function (response) {
+      t.equal(response.statusCode, 200);
+      t.equal(response.body, undefined);
+      return client.getTyped('email', 'picard@example.com');
+    }).then(function (response) {
+      t.equal(response.statusCode, 404);
+      t.equal(response.body, undefined); // JSON.stringify() -> undefined
       t.end();
     });
   }

--- a/test/local/reputation_service_client_tests.js
+++ b/test/local/reputation_service_client_tests.js
@@ -80,6 +80,14 @@ test(
 );
 
 test(
+  'does not get reputation for a invalid type',
+  function (t) {
+    t.rejects(client.getTyped('not-real', 'foobar'), new Error('Invalid type: not-real'));
+    t.end();
+  }
+);
+
+test(
   'does not get reputation for a invalid email',
   function (t) {
     t.rejects(client.getTyped('email', 'not-an-email'), invalidEmailError);


### PR DESCRIPTION
Removes the use of legacy iprepd endpoints and makes use of the new
typed endpoints. This PR maintains the current API and extends it with
new '<_>Typed' functions.

Fixes #39

----

@g-k There is one part I am still unsure of how to deal with, and that is the change from the response body for "get reputation" calls using `ip` as a key to now using `object`. The compat code in iprepd for this is here: https://github.com/mozilla-services/iprepd/blob/cd62a1f65e61ff91480ee07a0fa56232e2b471f8/score.go#L162-L172

Is there someway for me to include a compat layer in the returned Promise from `getTyped()`? How do I do something like that with Promises? 