### PR TITLE
Update docs, testing changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - sleep 15
   - docker-compose up -d web
   - sleep 15
-  - docker-compose run --rm test npm test
+  - docker-compose run --rm test
   - coveralls < $TRAVIS_BUILD_DIR/coverage/lcov.info
 
 after_install:

--- a/README.md
+++ b/README.md
@@ -60,5 +60,8 @@ client.sendViolation('127.0.0.1', 'exceeded-password-reset-failure-rate-limit').
 Tests run against [the iprepd service](https://github.com/mozilla-services/iprepd) with [docker-compose](https://docs.docker.com/compose/) from the ip-reputation-js-client repo root:
 
 1. Install [docker](https://docs.docker.com/install/) and [docker-compose](https://docs.docker.com/compose/install/)
-1. Run `docker-compose build` then `docker-compose run --rm test` (note: this may fail on the first run, but should work on subsequent runs due to the web and test containers not waiting long enough for the cache and web servers to start)
+1. Run `docker-compose build`.
+1. Run `docker-compose run --rm test npm install` to collect package dependencies.
+1. Run `docker-compose run --rm test` to test.
 1. Open `coverage/lcov-report/index.html` to see the coverage report
+1. Run `docker-compose down` when you are finished running tests to remove cache and web containers.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
-### iprepd (IP Reputation Service) node.js client library
+## iprepd (IP Reputation Service) node.js client library
 
-Client library to send IP reputations to [the iprepd service](https://github.com/mozilla-services/iprepd).
+Client library to send object reputations to [the iprepd service](https://github.com/mozilla-services/iprepd).
 
 [![npm version](https://badge.fury.io/js/ip-reputation-js-client.svg)](https://www.npmjs.com/package/ip-reputation-js-client) [![Coverage Status](https://coveralls.io/repos/github/mozilla-services/ip-reputation-js-client/badge.svg?branch=master)](https://coveralls.io/github/mozilla-services/ip-reputation-js-client?branch=master) [![Build Status](https://travis-ci.org/mozilla-services/ip-reputation-js-client.svg?branch=master)](https://travis-ci.org/mozilla-services/ip-reputation-js-client)
 
-Usage:
+### Overview
+
+iprepd is a service that supports storing and retrieving reputations associated with various object
+types, the most common being IP addresses but including others such as account names and email
+addresses. This library can be used by Node applications to integrate directly with this API.
+
+### Usage
+
+#### Functions
 
 Create a client:
 
@@ -18,6 +26,48 @@ const client = new IPReputationClient({
     timeout: <number in ms>
 })
 ```
+
+Get the reputation for an IP:
+
+```js
+client.getTyped('ip', '127.0.0.1').then(function (response) {
+    if (response && response.statusCode === 404) {
+        console.log('No reputation found for 127.0.0.1');
+    } else {
+        console.log('127.0.0.1 has reputation: ', response.body.reputation);
+    }
+});
+```
+
+Set the reputation for an IP:
+
+```js
+client.updateTyped('ip', '127.0.0.1', 79).then(function (response) {
+    console.log('Set reputation for 127.0.0.1 to 79.');
+});
+```
+
+Remove an IP:
+
+```js
+client.removeTyped('ip', '127.0.0.1').then(function (response) {
+    console.log('Removed reputation for 127.0.0.1.');
+});
+```
+
+Send a violation for an IP:
+
+```js
+client.sendViolationTyped('ip', '127.0.0.1', 'exceeded-password-reset-failure-rate-limit').then(function (response) {
+    console.log('Applied violation to 127.0.0.1.');
+});
+```
+
+#### Legacy functions
+
+Previous versions of iprepd only supported IP addresses; these functions remain as a compatibility
+layer for applications that still make use of them, and are essentially wrappers around the typed
+function calls.
 
 Get the reputation for an IP:
 
@@ -55,7 +105,7 @@ client.sendViolation('127.0.0.1', 'exceeded-password-reset-failure-rate-limit').
 });
 ```
 
-## Development
+### Development
 
 Tests run against [the iprepd service](https://github.com/mozilla-services/iprepd) with [docker-compose](https://docs.docker.com/compose/) from the ip-reputation-js-client repo root:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
   test:
     image: node:12-alpine
     environment:
-      - DEVELOPMENT=1
       - IPREPD_ADDR=web:8080
     links:
       - web

--- a/package-lock.json
+++ b/package-lock.json
@@ -391,15 +391,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
-    "audit-filter": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/audit-filter/-/audit-filter-0.3.0.tgz",
-      "integrity": "sha512-/JVgvA6bVj9D4Nw3ik6smcDTJFudUXGJApOlST3Lar17E1UjYYSSl9bc/ASZNg+2nJobqdQTZXsk21WrADtaew==",
-      "dev": true,
-      "requires": {
-        "docopt": "^0.6.2"
-      }
-    },
     "auto-bind": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-2.1.0.tgz",
@@ -1238,12 +1229,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
       "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
-      "dev": true
-    },
-    "docopt": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/docopt/-/docopt-0.6.2.tgz",
-      "integrity": "sha1-so6eIiDaXsSffqW7JKR3h0Be6xE=",
       "dev": true
     },
     "doctrine": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "request": "2.87.0"
   },
   "devDependencies": {
-    "audit-filter": "0.3.0",
     "eslint-plugin-fxa": "1.0.0",
     "grunt": "1.0.4",
     "grunt-bump": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ip-reputation-js-client",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "A node.js client library to the IP reputation service/iprepd",
   "main": "lib/client.js",
   "files": [

--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -1,33 +1,12 @@
 #!/bin/sh
 
+set -e
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# default variables
-: "${PORT:=8080}"
-: "${SLEEP:=1}"
-: "${TRIES:=60}"
-
-wait_for() {
-  tries=0
-  echo "Waiting for $1 to listen on $2..."
-  while true; do
-    [[ $tries -lt $TRIES ]] || return
-    (echo > /dev/tcp/$1/$2) >/dev/null 2>&1
-    result=
-    [[ $? -eq 0 ]] && return
-    sleep $SLEEP
-    tries=$((tries + 1))
-  done
-}
-
-# Only wait for backend services in development
-# http://stackoverflow.com/a/13864829
-# For example, docker-compose.yml sets 'DEVELOPMENT' to 1
-[ ! -z ${DEVELOPMENT+check} ] && wait_for web 8080 && sleep 3
-
-npm run-script lint:deps || exit 1
-node_modules/.bin/grunt lint copyright || exit 1
-node_modules/.bin/nyc tap test/local/reputation_service_client_tests.js || exit 1
+npm run-script lint:deps
+node_modules/.bin/grunt lint copyright
+node_modules/.bin/nyc tap test/local/reputation_service_client_tests.js
 node_modules/.bin/nyc report --reporter=lcov

--- a/test/local/reputation_service_client_tests.js
+++ b/test/local/reputation_service_client_tests.js
@@ -128,6 +128,14 @@ test(
 );
 
 test(
+  'does not sendViolationTyped for a invalid IP',
+  function (t) {
+    t.rejects(client.sendViolationTyped('ip', 'not-an-ip', 'test_violation'), invalidIPError);
+    t.end();
+  }
+);
+
+test(
   'update reputation for new email',
   function (t) {
     client.updateTyped('email', 'picard@example.com', 50).then(function (response) {
@@ -263,6 +271,25 @@ test(
       t.equal(response.statusCode, 200);
       t.equal(response.body.reputation, 70);
       t.equal(response.body.ip, '127.0.0.1');
+      t.equal(response.body.reviewed, false);
+      t.end();
+    });
+  }
+);
+
+test(
+  'sends a typed violation',
+  function (t) {
+    client.get('127.0.0.2').then(function (response) {
+      t.equal(response.statusCode, 404);
+      return client.sendViolationTyped('ip', '127.0.0.2', 'test_violation');
+    }).then(function (response) {
+      t.equal(response.statusCode, 200);
+      return client.get('127.0.0.2');
+    }).then(function (response) {
+      t.equal(response.statusCode, 200);
+      t.equal(response.body.reputation, 70);
+      t.equal(response.body.ip, '127.0.0.2');
       t.equal(response.body.reviewed, false);
       t.end();
     });


### PR DESCRIPTION
* Remove `audit-filter` which @g-k mentioned we don't need here right now.

* Remove a bunch of code from the CI tasks which I don't believe we need anymore.

* Update testing documentation to include steps to fetch dependencies which is required prior to running tests unless they are running in Travis, which will do this for us.

* Update the README to include the preferred new function calls, in addition to the legacy compatibility functions.

* Add missing tests for typed violation submission.

* Bump version to 6.0.0 in preparation for pushing this to npm and integrating the new module with FxA.

Closes #43 