### PR TITLE
fix(client.js): Update cidr to a valid value per joi documentation

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -22,7 +22,7 @@ var ipSchema = Joi.string().ip({
   version: [
     'ipv4',
   ],
-  cidr: false
+  cidr: 'forbidden'
 });
 
 var emailSchema = Joi.string().email();


### PR DESCRIPTION
## Because
- Currently `options.cidr` is set to the boolean value of `false`. Per [joi documentation](https://joi.dev/api/?v=17.8.1#stringipoptions), the valid values for `cidr` are: optional, required, forbidden.

## This pull request
- updates cidr to `forbidden`, as the backend only accepts non-CIDR IPv4 (see line 19)